### PR TITLE
fix: use global CLI variable instead of local for flag parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,8 @@ type RetVal struct {
 	ChangedPort  int    // what port did the STUN server see after we sent a change request
 }
 
+var CLI CLIFlags
+
 type CLIFlags struct {
 	STUNServers []string `help:"STUN servers to use for detection" name:"stun-server" short:"s"`
 	STUNPort    int      `help:"STUN port to use for detection" default:"3478" short:"p"`
@@ -61,7 +63,6 @@ type CLIFlags struct {
 	NoIP        bool     `help:"Omit IP addresses in output" default:"false" short:"o"`
 }
 
-var CLI CLIFlags
 var logger *zap.SugaredLogger
 
 var (
@@ -80,12 +81,12 @@ func main() {
 	math.New(math.NewSource(time.Now().UnixNano()))
 
 	var cli CLIFlags
-	kctx := kong.Parse(&cli,
+	kctx := kong.Parse(&CLI,
+		// kctx := kong.Parse(&cli,
 		kong.Name("stunner"),
 		kong.Description("A CLI tool to check your NAT Type"),
 		kong.Vars{"version": Version},
 	)
-	
 
 	if cli.Version {
 		fmt.Printf("stunner %s\n", Version)
@@ -672,4 +673,3 @@ func printTables(results []PerServerResult, finalNAT string) {
 	tbl2.SetBorder(true)
 	tbl2.Render()
 }
-


### PR DESCRIPTION
Fixed DERP map fetching error by removing unused local cli variable  and parsing flags directly into global CLI variable. This ensures  command-line arguments are properly accessible throughout the program.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use global `CLI` variable for flag parsing in `main()` to fix DERP map fetching error.
> 
>   - **Behavior**:
>     - Use global `CLI` variable for flag parsing in `main()` instead of local `cli` variable.
>     - Fixes DERP map fetching error by ensuring command-line arguments are accessible globally.
>   - **Code Changes**:
>     - Remove local `cli` variable in `main()`.
>     - Parse flags directly into global `CLI` variable in `main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Fstunner&utm_source=github&utm_medium=referral)<sup> for ff5a72180acebf4676188e10b753412bf81be09d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->