### PR TITLE
fix linux install instructions and add go install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ curl -L "https://github.com/jaxxstorm/stunner/releases/download/${VERSION}/stunn
 ./stunner --version
 ```
 
+### Using Go
+
+If you have go installed you can build and install with
+
+```
+go install github.com/jaxxstorm/stunner@v0.0.8
+```
+
+The resulting binary will appear inside `$GOPATH/bin` which you may want in your `PATH`.
+
+You can run `go env | grep "GOPATH"` to double check where go considers the `GOPATH` to be.
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Download the binary from releases
 
 
 ```
-VERSION=v0.0.5
-cur -L "https://github.com/jaxxstorm/stunner/releases/download/${VERSION}/stunner-${VERSION}-linux-amd64.tar.gz" | tar -xz
+VERSION=v0.0.8
+curl -L "https://github.com/jaxxstorm/stunner/releases/download/${VERSION}/stunner-${VERSION}-linux-amd64.tar.gz" | tar -xz
 ./stunner --version
 ```
 


### PR DESCRIPTION
* Fixed typo in linux install instructions & bumped the version
* Added install instructions for if you have `go`

Install instructions for Linux/Mac via nix to come once [nixos/nixpgs#387280](https://nixpk.gs/pr-tracker.html?pr=387280) hits at least unstable 🙂 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Linux install typo, update version, and add Go install method in `README.md`.
> 
>   - **Installation Instructions**:
>     - Fix typo in Linux installation instructions in `README.md`.
>     - Update version number from `v0.0.5` to `v0.0.8` in Linux installation instructions.
>     - Add Go installation method in `README.md`, allowing users to build and install using `go install github.com/jaxxstorm/stunner@latest`.
>   - **Misc**:
>     - Mention upcoming Nix installation instructions once `nixos/nixpgs#387280` is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Fstunner&utm_source=github&utm_medium=referral)<sup> for defda3f26384962feca4aa65fb8be619c0c1553a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->