### PR TITLE
README: update install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - **Verbose Debug Logging**: An optional `--debug` flag emits debug logs akin to `pystun3`, letting you trace each request/response.
 - **Tabular Output**: Results are displayed in tables for easy reading, e.g.:
 
-```
+```bash
 +----------------------------+-------+-----------+---------+
 |        STUN SERVER         | PORT  |    IP     | MAPPING |
 +----------------------------+-------+-----------+---------+
@@ -32,7 +32,7 @@
 
 Install from homebrew:
 
-```
+```bash
 brew install jaxxstorm/tap/stunner
 ```
 
@@ -40,9 +40,8 @@ brew install jaxxstorm/tap/stunner
 
 Download the binary from releases
 
-
-```
-VERSION=v0.0.8
+```bash
+VERSION=v0.0.10
 curl -L "https://github.com/jaxxstorm/stunner/releases/download/${VERSION}/stunner-${VERSION}-linux-amd64.tar.gz" | tar -xz
 ./stunner --version
 ```
@@ -51,8 +50,8 @@ curl -L "https://github.com/jaxxstorm/stunner/releases/download/${VERSION}/stunn
 
 If you have go installed you can build and install with
 
-```
-go install github.com/jaxxstorm/stunner@v0.0.8
+```bash
+go install github.com/jaxxstorm/stunner@latest
 ```
 
 The resulting binary will appear inside `$GOPATH/bin` which you may want in your `PATH`.
@@ -121,4 +120,3 @@ Stunner will:
 MIT
 
 ---
-


### PR DESCRIPTION
Make go install grab the latest release.
Update curl to pull latest version.

Fix some markdown lint errors also.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `README.md` to install the latest version and fix markdown syntax.
> 
>   - **Installation Instructions**:
>     - Update Go install command to `go install github.com/jaxxstorm/stunner@latest` in `README.md`.
>     - Update curl command to use `VERSION=v0.0.10` for downloading the latest release.
>   - **Markdown Fixes**:
>     - Correct markdown syntax for code blocks by specifying `bash` language in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Fstunner&utm_source=github&utm_medium=referral)<sup> for d933fb5eaf2030d1dcf9df9aa9772146136ef366. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->